### PR TITLE
Add additional external connectivity Checks to kconmon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,11 @@ RUN addgroup nonroot && \
     adduser -D nonroot -G nonroot && \
     chown nonroot:nonroot /app
 
+RUN apk update && \
+    apk add --no-cache iputils
+
 USER nonroot
+
 RUN mkdir -p /home/nonroot/.npm
 VOLUME /home/nonroot/.npm
 COPY package.json ./

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,7 +35,8 @@ const mochaConfig = {
 
 const eslintConfig = {
   options: {
-    configFile: '.eslintrc.js'
+    configFile: '.eslintrc.js',
+    fix: true
   },
   target: config.targets.ts
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
   controller:
-    image: barto92/kubemon:${VERSION:-latest}
+    image: stono/kconmon:${VERSION:-latest}
     build:
       context: '.'
       args:
@@ -24,7 +24,7 @@ services:
       - ~/.kube:/home/nonroot/.kube:ro
 
   agent:
-    image: barto92/kubemon:${VERSION:-latest}
+    image: stono/kconmon:${VERSION:-latest}
     command: 'agent'
     environment:
       PORT: '80' # Run on port 80 locally in docker-compose to replicate kubernetes service object port magenting

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
   controller:
-    image: stono/kconmon:${VERSION:-latest}
+    image: barto92/kubemon:${VERSION:-latest}
     build:
       context: '.'
       args:
@@ -24,7 +24,7 @@ services:
       - ~/.kube:/home/nonroot/.kube:ro
 
   agent:
-    image: stono/kconmon:${VERSION:-latest}
+    image: barto92/kubemon:${VERSION:-latest}
     command: 'agent'
     environment:
       PORT: '80' # Run on port 80 locally in docker-compose to replicate kubernetes service object port magenting

--- a/helmfile/charts/kconmon/values.yaml
+++ b/helmfile/charts/kconmon/values.yaml
@@ -1,6 +1,6 @@
 docker:
   image: barto92/kubemon
-  tag: 1.0.30
+  tag: 1.0.40
 
 # Should we run an initContainer that enables core tcp connection setting tweaks
 # Note: This requires kernel 4+

--- a/helmfile/charts/kconmon/values.yaml
+++ b/helmfile/charts/kconmon/values.yaml
@@ -1,6 +1,6 @@
 docker:
   image: barto92/kubemon
-  tag: 1.0.40
+  tag: 1.0.41
 
 # Should we run an initContainer that enables core tcp connection setting tweaks
 # Note: This requires kernel 4+

--- a/helmfile/charts/kconmon/values.yaml
+++ b/helmfile/charts/kconmon/values.yaml
@@ -50,8 +50,8 @@ config:
       - www.google.com
       - 8.8.4.4
 
-# Custom TCP tests configuration
-  custom_tcp:
+# Custom HTTP tests configuration
+  custom_http:
     enable: true
     interval: 5000
     timeout: 1000

--- a/helmfile/charts/kconmon/values.yaml
+++ b/helmfile/charts/kconmon/values.yaml
@@ -1,6 +1,6 @@
 docker:
   image: barto92/kubemon
-  tag: 1.0.41
+  tag: latest
 
 # Should we run an initContainer that enables core tcp connection setting tweaks
 # Note: This requires kernel 4+
@@ -40,6 +40,7 @@ config:
       - kubernetes.default.svc.cluster.local
   
   icmp:
+    enable: true
     interval: 5000
     count: 2
     timeout: 5
@@ -48,6 +49,7 @@ config:
       - www.google.com
       - 8.8.4.4
   custom_tcp:
+    enable: true
     interval: 5000
     timeout: 1000
     hosts:

--- a/helmfile/charts/kconmon/values.yaml
+++ b/helmfile/charts/kconmon/values.yaml
@@ -1,5 +1,6 @@
 docker:
-  image: stono/kconmon
+  image: barto92/kubemon
+  tag: 1.0.30
 
 # Should we run an initContainer that enables core tcp connection setting tweaks
 # Note: This requires kernel 4+
@@ -37,6 +38,21 @@ config:
     hosts:
       - www.google.com
       - kubernetes.default.svc.cluster.local
+  
+  icmp:
+    interval: 5000
+    count: 2
+    timeout: 5
+    hosts:
+      - www.telekom.de
+      - www.google.com
+      - 8.8.4.4
+  custom_tcp:
+    interval: 5000
+    timeout: 1000
+    hosts:
+      - www.telekom.de
+      - www.google.de
 
 resources:
   agent:

--- a/helmfile/charts/kconmon/values.yaml
+++ b/helmfile/charts/kconmon/values.yaml
@@ -1,5 +1,5 @@
 docker:
-  image: barto92/kubemon
+  image: stono/kconmon
   tag: latest
 
 # Should we run an initContainer that enables core tcp connection setting tweaks
@@ -38,7 +38,8 @@ config:
     hosts:
       - www.google.com
       - kubernetes.default.svc.cluster.local
-  
+
+# ICMP Test configuration
   icmp:
     enable: true
     interval: 5000
@@ -48,6 +49,8 @@ config:
       - www.telekom.de
       - www.google.com
       - 8.8.4.4
+
+# Custom TCP tests configuration
   custom_tcp:
     enable: true
     interval: 5000

--- a/lib/apps/agent/metrics.ts
+++ b/lib/apps/agent/metrics.ts
@@ -1,14 +1,17 @@
 export interface IMetrics {
   handleTCPTestResult(result: ITCPTestResult)
+  handleCustomTCPTestResult(result: ICustomTCPTestResult)
   handleUDPTestResult(result: IUDPTestResult)
   handleDNSTestResult(result: IDNSTestResult)
+  handleICMPTestResult(result: IICMPTestResult)
   resetTCPTestResults()
+  resetCustomTCPTestResults()
   resetUDPTestResults()
   toString()
 }
 
 import * as client from 'prom-client'
-import { IUDPTestResult, IDNSTestResult, ITCPTestResult } from 'lib/tester'
+import { IICMPTestResult, IUDPTestResult, IDNSTestResult, ITCPTestResult, ICustomTCPTestResult } from 'lib/tester'
 import { IConfig } from 'lib/config'
 
 export default class Metrics implements IMetrics {
@@ -23,6 +26,16 @@ export default class Metrics implements IMetrics {
 
   private DNS: client.Counter<string>
   private DNSDuration: client.Gauge<string>
+
+  private ICMP: client.Counter<string>
+  private ICMPDuration: client.Gauge<string>
+  private ICMPAverage: client.Gauge<string>
+  private ICMPStddv: client.Gauge<string>
+  private ICMPLoss: client.Gauge<string>
+
+  private CustomTCP: client.Counter<string>
+  private CustomTCPDuration: client.Gauge<string>
+  private CustomTCPConnect: client.Gauge<string>
 
   constructor(config: IConfig) {
     client.register.clear()
@@ -68,6 +81,36 @@ export default class Metrics implements IMetrics {
       name: `${config.metricsPrefix}_dns_duration_milliseconds`
     })
 
+    this.ICMP = new client.Counter<string>({
+      help: 'ICMP Test Results',
+      labelNames: ['source', 'source_zone', 'host', 'result'],
+      name: `${config.metricsPrefix}_icmp_results_total`
+    })
+
+    this.ICMPDuration = new client.Gauge<string>({
+      help: 'Total time taken to complete the ICMP test',
+      labelNames: ['source', 'source_zone', 'host'],
+      name: `${config.metricsPrefix}_icmp_duration_milliseconds`
+    })
+
+    this.ICMPAverage = new client.Gauge<string>({
+      help: 'ICMP average packet RTT',
+      labelNames: ['source', 'destination', 'host'],
+      name: `${config.metricsPrefix}_icmp_average_rtt_milliseconds`
+    })
+
+    this.ICMPStddv = new client.Gauge<string>({
+      help: 'ICMP standard deviation of RTT',
+      labelNames: ['source', 'destination', 'host'],
+      name: `${config.metricsPrefix}_icmp_standard_deviation_rtt_milliseconds`
+    })
+
+    this.ICMPLoss = new client.Gauge<string>({
+      help: 'ICMP packet loss',
+      labelNames: ['source', 'destination', 'host'],
+      name: `${config.metricsPrefix}_icmp_packet_loss`
+    })
+
     this.UDP = new client.Counter<string>({
       help: 'UDP Test Results',
       labelNames: [
@@ -91,6 +134,61 @@ export default class Metrics implements IMetrics {
       ],
       name: `${config.metricsPrefix}_tcp_results_total`
     })
+
+    this.CustomTCP = new client.Counter<string>({
+      help: 'Custom TCP Test Results',
+      labelNames: [
+        'source',
+        'destination',
+        'source_zone',
+        'destination_zone',
+        'result'
+      ],
+      name: `${config.metricsPrefix}_custom_tcp_results_total`
+    })
+
+    this.CustomTCPConnect = new client.Gauge<string>({
+      help: 'Time taken to establish the TCP socket for custom test',
+      labelNames: ['source', 'destination', 'source_zone', 'destination_zone'],
+      name: `${config.metricsPrefix}_custom_tcp_connect_milliseconds`
+    })
+
+    this.CustomTCPDuration = new client.Gauge<string>({
+      help: 'Total time taken to complete the custom TCP test',
+      labelNames: ['source', 'destination', 'source_zone', 'destination_zone'],
+      name: `${config.metricsPrefix}_custom_tcp_duration_milliseconds`
+    })
+
+  }
+
+  public handleICMPTestResult(result: IICMPTestResult): void {
+    const source = result.source.nodeName
+    this.ICMP.labels(source, result.source.zone, result.host, result.result).inc(
+      1
+    )
+    this.ICMPDuration.labels(
+      result.source.nodeName,
+      result.source.zone,
+      result.host
+    ).set(result.duration)
+
+    this.ICMPAverage.labels(
+      result.source.nodeName,
+      result.source.zone,
+      result.host
+    ).set(result.avg)
+    
+    this.ICMPStddv.labels(
+      result.source.nodeName,
+      result.source.zone,
+      result.host
+    ).set(result.stddev)
+
+    this.ICMPLoss.labels(
+      result.source.nodeName,
+      result.source.zone,
+      result.host
+    ).set(result.loss)
   }
 
   public handleDNSTestResult(result: IDNSTestResult): void {
@@ -181,6 +279,44 @@ export default class Metrics implements IMetrics {
         destinationZone
       ).set(result.timings.phases.total as number)
     }
+  }
+
+  public handleCustomTCPTestResult(result: ICustomTCPTestResult): void {
+    const source = result.source.nodeName
+    const destination = result.destination
+    const sourceZone = result.source.zone
+    const destinationZone = result.destination
+    this.CustomTCP.labels(
+      source,
+      destination,
+      sourceZone,
+      destinationZone,
+      result.result
+    ).inc(1)
+
+    if (result.timings) {
+      this.CustomTCPConnect.labels(
+        source,
+        destination,
+        sourceZone,
+        destinationZone
+      ).set(
+        ((result.timings.connect ||
+          result.timings.socket ||
+          result.timings.start) - result.timings.start) as number
+      )
+      this.CustomTCPDuration.labels(
+        source,
+        destination,
+        sourceZone,
+        destinationZone
+      ).set(result.timings.phases.total as number)
+    }
+  }
+
+  public resetCustomTCPTestResults() {
+    this.CustomTCPConnect.reset()
+    this.CustomTCPDuration.reset()
   }
 
   public toString(): string {

--- a/lib/apps/agent/metrics.ts
+++ b/lib/apps/agent/metrics.ts
@@ -11,7 +11,13 @@ export interface IMetrics {
 }
 
 import * as client from 'prom-client'
-import { IICMPTestResult, IUDPTestResult, IDNSTestResult, ITCPTestResult, ICustomTCPTestResult } from 'lib/tester'
+import {
+  IICMPTestResult,
+  IUDPTestResult,
+  IDNSTestResult,
+  ITCPTestResult,
+  ICustomTCPTestResult
+} from 'lib/tester'
 import { IConfig } from 'lib/config'
 
 export default class Metrics implements IMetrics {
@@ -158,14 +164,16 @@ export default class Metrics implements IMetrics {
       labelNames: ['source', 'destination', 'source_zone', 'destination_zone'],
       name: `${config.metricsPrefix}_custom_tcp_duration_milliseconds`
     })
-
   }
 
   public handleICMPTestResult(result: IICMPTestResult): void {
     const source = result.source.nodeName
-    this.ICMP.labels(source, result.source.zone, result.host, result.result).inc(
-      1
-    )
+    this.ICMP.labels(
+      source,
+      result.source.zone,
+      result.host,
+      result.result
+    ).inc(1)
     this.ICMPDuration.labels(
       result.source.nodeName,
       result.source.zone,
@@ -177,7 +185,7 @@ export default class Metrics implements IMetrics {
       result.source.zone,
       result.host
     ).set(result.avg)
-    
+
     this.ICMPStddv.labels(
       result.source.nodeName,
       result.source.zone,

--- a/lib/apps/agent/metrics.ts
+++ b/lib/apps/agent/metrics.ts
@@ -1,11 +1,11 @@
 export interface IMetrics {
   handleTCPTestResult(result: ITCPTestResult)
-  handleCustomTCPTestResult(result: ICustomTCPTestResult)
+  handleCustomHTTPTestResult(result: ICustomHTTPTestResult)
   handleUDPTestResult(result: IUDPTestResult)
   handleDNSTestResult(result: IDNSTestResult)
   handleICMPTestResult(result: IICMPTestResult)
   resetTCPTestResults()
-  resetCustomTCPTestResults()
+  resetCustomHTTPTestResults()
   resetUDPTestResults()
   toString()
 }
@@ -16,7 +16,7 @@ import {
   IUDPTestResult,
   IDNSTestResult,
   ITCPTestResult,
-  ICustomTCPTestResult
+  ICustomHTTPTestResult
 } from 'lib/tester'
 import { IConfig } from 'lib/config'
 
@@ -39,9 +39,9 @@ export default class Metrics implements IMetrics {
   private ICMPStddv: client.Gauge<string>
   private ICMPLoss: client.Gauge<string>
 
-  private CustomTCP: client.Counter<string>
-  private CustomTCPDuration: client.Gauge<string>
-  private CustomTCPConnect: client.Gauge<string>
+  private CustomHTTP: client.Counter<string>
+  private CustomHTTPDuration: client.Gauge<string>
+  private CustomHTTPConnect: client.Gauge<string>
 
   constructor(config: IConfig) {
     client.register.clear()
@@ -141,7 +141,7 @@ export default class Metrics implements IMetrics {
       name: `${config.metricsPrefix}_tcp_results_total`
     })
 
-    this.CustomTCP = new client.Counter<string>({
+    this.CustomHTTP = new client.Counter<string>({
       help: 'Custom TCP Test Results',
       labelNames: [
         'source',
@@ -150,19 +150,19 @@ export default class Metrics implements IMetrics {
         'destination_zone',
         'result'
       ],
-      name: `${config.metricsPrefix}_custom_tcp_results_total`
+      name: `${config.metricsPrefix}_custom_http_results_total`
     })
 
-    this.CustomTCPConnect = new client.Gauge<string>({
+    this.CustomHTTPConnect = new client.Gauge<string>({
       help: 'Time taken to establish the TCP socket for custom test',
       labelNames: ['source', 'destination', 'source_zone', 'destination_zone'],
-      name: `${config.metricsPrefix}_custom_tcp_connect_milliseconds`
+      name: `${config.metricsPrefix}_custom_http_connect_milliseconds`
     })
 
-    this.CustomTCPDuration = new client.Gauge<string>({
+    this.CustomHTTPDuration = new client.Gauge<string>({
       help: 'Total time taken to complete the custom TCP test',
       labelNames: ['source', 'destination', 'source_zone', 'destination_zone'],
-      name: `${config.metricsPrefix}_custom_tcp_duration_milliseconds`
+      name: `${config.metricsPrefix}_custom_http_duration_milliseconds`
     })
   }
 
@@ -289,12 +289,12 @@ export default class Metrics implements IMetrics {
     }
   }
 
-  public handleCustomTCPTestResult(result: ICustomTCPTestResult): void {
+  public handleCustomHTTPTestResult(result: ICustomHTTPTestResult): void {
     const source = result.source.nodeName
     const destination = result.destination
     const sourceZone = result.source.zone
     const destinationZone = result.destination
-    this.CustomTCP.labels(
+    this.CustomHTTP.labels(
       source,
       destination,
       sourceZone,
@@ -303,7 +303,7 @@ export default class Metrics implements IMetrics {
     ).inc(1)
 
     if (result.timings) {
-      this.CustomTCPConnect.labels(
+      this.CustomHTTPConnect.labels(
         source,
         destination,
         sourceZone,
@@ -313,7 +313,7 @@ export default class Metrics implements IMetrics {
           result.timings.socket ||
           result.timings.start) - result.timings.start) as number
       )
-      this.CustomTCPDuration.labels(
+      this.CustomHTTPDuration.labels(
         source,
         destination,
         sourceZone,
@@ -322,9 +322,9 @@ export default class Metrics implements IMetrics {
     }
   }
 
-  public resetCustomTCPTestResults() {
-    this.CustomTCPConnect.reset()
-    this.CustomTCPDuration.reset()
+  public resetCustomHTTPTestResults() {
+    this.CustomHTTPConnect.reset()
+    this.CustomHTTPDuration.reset()
   }
 
   public toString(): string {

--- a/lib/apps/agent/metrics.ts
+++ b/lib/apps/agent/metrics.ts
@@ -101,19 +101,19 @@ export default class Metrics implements IMetrics {
 
     this.ICMPAverage = new client.Gauge<string>({
       help: 'ICMP average packet RTT',
-      labelNames: ['source', 'destination', 'host'],
+      labelNames: ['source', 'source_zone', 'host'],
       name: `${config.metricsPrefix}_icmp_average_rtt_milliseconds`
     })
 
     this.ICMPStddv = new client.Gauge<string>({
       help: 'ICMP standard deviation of RTT',
-      labelNames: ['source', 'destination', 'host'],
+      labelNames: ['source', 'source_zone', 'host'],
       name: `${config.metricsPrefix}_icmp_standard_deviation_rtt_milliseconds`
     })
 
     this.ICMPLoss = new client.Gauge<string>({
       help: 'ICMP packet loss',
-      labelNames: ['source', 'destination', 'host'],
+      labelNames: ['source', 'source_zone', 'host'],
       name: `${config.metricsPrefix}_icmp_packet_loss`
     })
 

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -28,6 +28,17 @@ interface ITestConfiguration {
     interval: number
     hosts: string[]
   }
+  icmp: {
+    interval: number
+    count: number
+    timeout: number
+    hosts: string[]
+  }
+  custom_tcp: {
+    interval: number
+    timeout: number
+    hosts: string[]
+  }
 }
 
 export interface IConfig {
@@ -60,7 +71,9 @@ export class Config implements IConfig {
   public readonly testConfig: ITestConfiguration = {
     tcp: getEnv('tcp', { interval: 5000, timeout: 1000 }),
     udp: getEnv('udp', { interval: 5000, timeout: 250, packets: 10 }),
-    dns: getEnv('dns', { interval: 5000, hosts: [] })
+    dns: getEnv('dns', { interval: 5000, hosts: [] }),
+    icmp: getEnv('icmp', { interval: 5000, hosts: [] }),
+    custom_tcp: getEnv('custom_tcp', { interval: 5000, timeout: 1000, hosts: [] })
   }
 }
 

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -29,12 +29,14 @@ interface ITestConfiguration {
     hosts: string[]
   }
   icmp: {
+    enable: boolean
     interval: number
     count: number
     timeout: number
     hosts: string[]
   }
   custom_tcp: {
+    enable: boolean
     interval: number
     timeout: number
     hosts: string[]

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -35,7 +35,7 @@ interface ITestConfiguration {
     timeout: number
     hosts: string[]
   }
-  custom_tcp: {
+  custom_http: {
     enable: boolean
     interval: number
     timeout: number
@@ -75,7 +75,11 @@ export class Config implements IConfig {
     udp: getEnv('udp', { interval: 5000, timeout: 250, packets: 10 }),
     dns: getEnv('dns', { interval: 5000, hosts: [] }),
     icmp: getEnv('icmp', { interval: 5000, hosts: [] }),
-    custom_tcp: getEnv('custom_tcp', { interval: 5000, timeout: 1000, hosts: [] })
+    custom_http: getEnv('custom_http', {
+      interval: 5000,
+      timeout: 1000,
+      hosts: []
+    })
   }
 }
 

--- a/lib/tester/index.ts
+++ b/lib/tester/index.ts
@@ -7,6 +7,7 @@ import { IConfig } from 'lib/config'
 import Logger, { ILogger } from 'lib/logger'
 import * as dns from 'dns'
 import { IUdpClientFactory as IUDPClientFactory } from 'lib/udp/clientFactory'
+import * as ping from 'ping'
 
 export interface ITester {
   start()
@@ -14,6 +15,8 @@ export interface ITester {
   runUDPTests(agents: IAgent[]): Promise<IUDPTestResult[]>
   runTCPTests(agents: IAgent[]): Promise<ITCPTestResult[]>
   runDNSTests(): Promise<IDNSTestResult[]>
+  runICMPTests(): Promise<IICMPTestResult[]>
+  runCustomTCPTests(): Promise<ICustomTCPTestResult[]>
 }
 
 interface ITestResult {
@@ -29,11 +32,28 @@ export interface IDNSTestResult {
   result: 'pass' | 'fail'
 }
 
+export interface IICMPTestResult {
+  source: IAgent
+  host: string
+  duration: number,
+  avg: number,
+  stddev: number,
+  loss: number,
+  result: 'pass' | 'fail'
+}
+
 export interface IUDPTestResult extends ITestResult {
   timings?: IUDPPingResult
 }
 
 export interface ITCPTestResult extends ITestResult {
+  timings?: PlainResponse['timings']
+}
+
+export interface ICustomTCPTestResult {
+  source: IAgent
+  destination: string
+  result: 'pass' | 'fail'
   timings?: PlainResponse['timings']
 }
 
@@ -46,6 +66,7 @@ export default class Tester implements ITester {
   private running = false
   private config: IConfig
   private resolver = new dns.promises.Resolver()
+  // private ping: pingman
   private readonly udpClientFactory: IUDPClientFactory
 
   constructor(
@@ -102,15 +123,91 @@ export default class Tester implements ITester {
         await delay(this.config.testConfig.dns.interval + jitter())
       }
     }
+    const icmpEventLoop = async () => {
+      while (this.running) {
+        await this.runICMPTests()
+        await delay(this.config.testConfig.icmp.interval + jitter())
+      }
+    }
+    const tcpCustomEventLoop = async () => {
+      while (this.running) {
+        this.metrics.resetCustomTCPTestResults()
+        await this.runCustomTCPTests()
+        await delay(this.config.testConfig.custom_tcp.interval + jitter())
+      }
+    }
+
     agentUpdateLoop()
     tcpEventLoop()
     udpEventLoop()
     dnsEventLoop()
+    icmpEventLoop()
+    tcpCustomEventLoop()
   }
 
   public async stop(): Promise<void> {
     this.running = false
   }
+
+  public async runICMPTests(): Promise<IICMPTestResult[]> {
+    const promises = this.config.testConfig.icmp.hosts.map(
+      async (host): Promise<IICMPTestResult> => {
+        const hrstart = process.hrtime()
+        try {
+          const result = await ping.promise.probe(host, {
+            timeout: this.config.testConfig.icmp.timeout,
+            extra: ['-c', this.config.testConfig.icmp.count],
+          });
+          const hrend = process.hrtime(hrstart)
+          
+          if(result.alive){
+            const mapped: IICMPTestResult = {
+              source: this.me,
+              host,
+              duration: hrend[1] / 1000000,
+              avg: parseFloat(result.avg),
+              stddev: parseFloat(result.stddev),
+              loss: parseFloat(result.packetLoss),
+              result: 'pass'
+            }
+            this.metrics.handleICMPTestResult(mapped)
+            return mapped
+          } else {
+            const mapped: IICMPTestResult = {
+              source: this.me,
+              host,
+              duration: hrend[1] / 1000000,
+              avg: 0,
+              stddev: 0,
+              loss: parseFloat(result.packetLoss),
+              result: 'fail'
+            }
+            this.metrics.handleICMPTestResult(mapped)
+            return mapped
+          }          
+        } catch (ex) {
+          this.logger.error(`icmp test for ${host} failed`, ex)
+          const hrend = process.hrtime(hrstart)
+          const mapped: IICMPTestResult = {
+            source: this.me,
+            host,
+            duration: hrend[1] / 1000000,
+            avg: 0,
+            stddev: 0,
+            loss: 100.000,
+            result: 'fail'
+          }
+          this.metrics.handleICMPTestResult(mapped)
+          return mapped
+        }
+      }
+    )
+    const result = await Promise.allSettled(promises)
+    return result
+      .filter((r) => r.status === 'fulfilled')
+      .map((i) => (i as PromiseFulfilledResult<IICMPTestResult>).value)
+  }
+
 
   public async runDNSTests(): Promise<IDNSTestResult[]> {
     const promises = this.config.testConfig.dns.hosts.map(
@@ -224,5 +321,47 @@ export default class Tester implements ITester {
     return result
       .filter((r) => r.status === 'fulfilled')
       .map((i) => (i as PromiseFulfilledResult<ITCPTestResult>).value)
+  }
+
+  public async runCustomTCPTests(): Promise<ICustomTCPTestResult[]> {
+    const promises = this.config.testConfig.custom_tcp.hosts.map(
+      async (host): Promise<ICustomTCPTestResult> => {
+        try {
+          const url = `http://${host}`
+          const result = await this.got(url, {
+            timeout: this.config.testConfig.custom_tcp.timeout
+          })
+          const mappedResult: ICustomTCPTestResult = {
+            source: this.me,
+            destination: host,
+            timings: result.timings,
+            result: result.statusCode === 200 ? 'pass' : 'fail'
+          }
+          this.metrics.handleCustomTCPTestResult(mappedResult)
+          return mappedResult
+        } catch (ex) {
+          this.logger.warn(
+            `test failed`,
+            {
+              source: this.me,
+              destination: host
+            },
+            ex
+          )
+          const failResult: ICustomTCPTestResult = {
+            source: this.me,
+            destination: host,
+            result: 'fail'
+          }
+          this.metrics.handleCustomTCPTestResult(failResult)
+          return failResult
+        }
+      }
+    )
+    
+    const result = await Promise.allSettled(promises)
+    return result
+      .filter((r) => r.status === 'fulfilled')
+      .map((i) => (i as PromiseFulfilledResult<ICustomTCPTestResult>).value)
   }
 }

--- a/lib/tester/index.ts
+++ b/lib/tester/index.ts
@@ -141,8 +141,12 @@ export default class Tester implements ITester {
     tcpEventLoop()
     udpEventLoop()
     dnsEventLoop()
-    icmpEventLoop()
-    tcpCustomEventLoop()
+    if(this.config.testConfig.icmp.enable){
+      icmpEventLoop()
+    }
+    if(this.config.testConfig.custom_tcp.enable){
+      tcpCustomEventLoop()
+    }
   }
 
   public async stop(): Promise<void> {

--- a/lib/tester/index.ts
+++ b/lib/tester/index.ts
@@ -35,10 +35,10 @@ export interface IDNSTestResult {
 export interface IICMPTestResult {
   source: IAgent
   host: string
-  duration: number,
-  avg: number,
-  stddev: number,
-  loss: number,
+  duration: number
+  avg: number
+  stddev: number
+  loss: number
   result: 'pass' | 'fail'
 }
 
@@ -141,10 +141,10 @@ export default class Tester implements ITester {
     tcpEventLoop()
     udpEventLoop()
     dnsEventLoop()
-    if(this.config.testConfig.icmp.enable){
+    if (this.config.testConfig.icmp.enable) {
       icmpEventLoop()
     }
-    if(this.config.testConfig.custom_tcp.enable){
+    if (this.config.testConfig.custom_tcp.enable) {
       tcpCustomEventLoop()
     }
   }
@@ -160,11 +160,11 @@ export default class Tester implements ITester {
         try {
           const result = await ping.promise.probe(host, {
             timeout: this.config.testConfig.icmp.timeout,
-            extra: ['-c', this.config.testConfig.icmp.count],
-          });
+            extra: ['-c', this.config.testConfig.icmp.count]
+          })
           const hrend = process.hrtime(hrstart)
-          
-          if(result.alive){
+
+          if (result.alive) {
             const mapped: IICMPTestResult = {
               source: this.me,
               host,
@@ -188,7 +188,7 @@ export default class Tester implements ITester {
             }
             this.metrics.handleICMPTestResult(mapped)
             return mapped
-          }          
+          }
         } catch (ex) {
           this.logger.error(`icmp test for ${host} failed`, ex)
           const hrend = process.hrtime(hrstart)
@@ -198,7 +198,7 @@ export default class Tester implements ITester {
             duration: hrend[1] / 1000000,
             avg: 0,
             stddev: 0,
-            loss: 100.000,
+            loss: 100.0,
             result: 'fail'
           }
           this.metrics.handleICMPTestResult(mapped)
@@ -211,7 +211,6 @@ export default class Tester implements ITester {
       .filter((r) => r.status === 'fulfilled')
       .map((i) => (i as PromiseFulfilledResult<IICMPTestResult>).value)
   }
-
 
   public async runDNSTests(): Promise<IDNSTestResult[]> {
     const promises = this.config.testConfig.dns.hosts.map(
@@ -336,7 +335,7 @@ export default class Tester implements ITester {
             timeout: this.config.testConfig.custom_tcp.timeout
           })
           const htmlReponseCodes = [200, 301, 302, 304, 401]
-          if(htmlReponseCodes.includes(result.statusCode)){
+          if (htmlReponseCodes.includes(result.statusCode)) {
             const mappedResult: ICustomTCPTestResult = {
               source: this.me,
               destination: host,
@@ -355,7 +354,6 @@ export default class Tester implements ITester {
             this.metrics.handleCustomTCPTestResult(mappedResult)
             return mappedResult
           }
-          
         } catch (ex) {
           this.logger.warn(
             `test failed`,
@@ -375,7 +373,7 @@ export default class Tester implements ITester {
         }
       }
     )
-    
+
     const result = await Promise.allSettled(promises)
     return result
       .filter((r) => r.status === 'fulfilled')

--- a/lib/tester/index.ts
+++ b/lib/tester/index.ts
@@ -335,14 +335,27 @@ export default class Tester implements ITester {
           const result = await this.got(url, {
             timeout: this.config.testConfig.custom_tcp.timeout
           })
-          const mappedResult: ICustomTCPTestResult = {
-            source: this.me,
-            destination: host,
-            timings: result.timings,
-            result: result.statusCode === 200 ? 'pass' : 'fail'
+          const htmlReponseCodes = [200, 301, 302, 304, 401]
+          if(htmlReponseCodes.includes(result.statusCode)){
+            const mappedResult: ICustomTCPTestResult = {
+              source: this.me,
+              destination: host,
+              timings: result.timings,
+              result: 'pass'
+            }
+            this.metrics.handleCustomTCPTestResult(mappedResult)
+            return mappedResult
+          } else {
+            const mappedResult: ICustomTCPTestResult = {
+              source: this.me,
+              destination: host,
+              timings: result.timings,
+              result: 'fail'
+            }
+            this.metrics.handleCustomTCPTestResult(mappedResult)
+            return mappedResult
           }
-          this.metrics.handleCustomTCPTestResult(mappedResult)
-          return mappedResult
+          
         } catch (ex) {
           this.logger.warn(
             `test failed`,

--- a/lib/tester/index.ts
+++ b/lib/tester/index.ts
@@ -129,7 +129,7 @@ export default class Tester implements ITester {
         await delay(this.config.testConfig.icmp.interval + jitter())
       }
     }
-    const tcpCustomEventLoop = async () => {
+    const httpCustomEventLoop = async () => {
       while (this.running) {
         this.metrics.resetCustomHTTPTestResults()
         await this.runCustomHTTPTests()
@@ -145,7 +145,7 @@ export default class Tester implements ITester {
       icmpEventLoop()
     }
     if (this.config.testConfig.custom_http.enable) {
-      tcpCustomEventLoop()
+      httpCustomEventLoop()
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "tsconfig-paths": "3.9.0",
     "kubernetes-client": "9.0.0",
     "kubernetes-types": "1.17.0-beta.1",
-    "ts-xor": "1.0.8"
+    "ts-xor": "1.0.8",
+    "ping": "0.2.3"
   },
   "devDependencies": {
     "@types/express": "4.17.7",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
   },
   "devDependencies": {
     "@types/express": "4.17.7",
+    "@types/express-serve-static-core": "4.17.19",
     "@types/json-patch": "0.0.30",
     "@types/mocha": "8.0.0",
     "@types/node": "14.0.26",
+    "@types/underscore": "1.10.24",
     "@typescript-eslint/eslint-plugin": "3.7.0",
     "@typescript-eslint/parser": "3.7.0",
     "eslint": "7.5.0",

--- a/test/tester.test.ts
+++ b/test/tester.test.ts
@@ -19,6 +19,9 @@ describe('Tester', () => {
     config.testConfig.udp.timeout = 500
     config.testConfig.udp.packets = 1
     config.testConfig.tcp.timeout = 500
+    config.testConfig.custom_tcp.timeout = 500
+    config.testConfig.icmp.count = 2
+    config.testConfig.icmp.timeout = 5
     config.port = 8080
   })
 
@@ -29,6 +32,18 @@ describe('Tester', () => {
     got = td.function<Got>()
     udpClientFactory = td.object<IUdpClientFactory>()
     sut = new Tester(config, got, discovery, metrics, me, udpClientFactory)
+  })
+
+  it('should do a icmp test', async () => {
+    config.testConfig.icmp.hosts = ['www.google.com']
+    const result = await sut.runICMPTests()
+    should(result[0].result).eql('pass')
+  })
+
+  it('should do a custom tcp test', async () => {
+    config.testConfig.custom_tcp.hosts = ['www.google.com']
+    const result = await sut.runICMPTests()
+    should(result[0].result).eql('pass')
   })
 
   it('should do a dns test', async () => {

--- a/test/tester.test.ts
+++ b/test/tester.test.ts
@@ -19,8 +19,8 @@ describe('Tester', () => {
     config.testConfig.udp.timeout = 500
     config.testConfig.udp.packets = 1
     config.testConfig.tcp.timeout = 500
-    config.testConfig.custom_tcp.enable = true
-    config.testConfig.custom_tcp.timeout = 500
+    config.testConfig.custom_http.enable = true
+    config.testConfig.custom_http.timeout = 500
     config.testConfig.icmp.enable = true
     config.testConfig.icmp.count = 2
     config.testConfig.icmp.timeout = 5
@@ -43,11 +43,11 @@ describe('Tester', () => {
   })
 
   it('should do a custom tcp test', async () => {
-    config.testConfig.custom_tcp.hosts = ['www.google.com']
-    td.when(
-      got('http://www.google.com', { timeout: 500 })
-    ).thenResolve({ statusCode: 200 })
-    const result = await sut.runCustomTCPTests()
+    config.testConfig.custom_http.hosts = ['www.google.com']
+    td.when(got('http://www.google.com', { timeout: 500 })).thenResolve({
+      statusCode: 200
+    })
+    const result = await sut.runCustomHTTPTests()
     should(result[0].result).eql('pass')
   })
 

--- a/test/tester.test.ts
+++ b/test/tester.test.ts
@@ -42,7 +42,7 @@ describe('Tester', () => {
     should(result[0].result).eql('pass')
   })
 
-  it('should do a custom tcp test', async () => {
+  it('should do a custom http test', async () => {
     config.testConfig.custom_http.hosts = ['www.google.com']
     td.when(got('http://www.google.com', { timeout: 500 })).thenResolve({
       statusCode: 200

--- a/test/tester.test.ts
+++ b/test/tester.test.ts
@@ -44,6 +44,9 @@ describe('Tester', () => {
 
   it('should do a custom tcp test', async () => {
     config.testConfig.custom_tcp.hosts = ['www.google.com']
+    td.when(
+      got('http://www.google.com', { timeout: 500 })
+    ).thenResolve({ statusCode: 200 })
     const result = await sut.runCustomTCPTests()
     should(result[0].result).eql('pass')
   })

--- a/test/tester.test.ts
+++ b/test/tester.test.ts
@@ -19,7 +19,9 @@ describe('Tester', () => {
     config.testConfig.udp.timeout = 500
     config.testConfig.udp.packets = 1
     config.testConfig.tcp.timeout = 500
+    config.testConfig.custom_tcp.enable = true
     config.testConfig.custom_tcp.timeout = 500
+    config.testConfig.icmp.enable = true
     config.testConfig.icmp.count = 2
     config.testConfig.icmp.timeout = 5
     config.port = 8080
@@ -42,7 +44,7 @@ describe('Tester', () => {
 
   it('should do a custom tcp test', async () => {
     config.testConfig.custom_tcp.hosts = ['www.google.com']
-    const result = await sut.runICMPTests()
+    const result = await sut.runCustomTCPTests()
     should(result[0].result).eql('pass')
   })
 


### PR DESCRIPTION
We have the Use-Case of also monitoring some of our external connections as some of our Networks are a bit flaky sometimes and we want be able to detect that.
This PR impliments  external ICMP and HTTP connection checks to for example monitor your rough network latency (routing changes e.g.) and status of connection to for example your registry,