### PR TITLE
Add files for automatic scraping with Prometheus Operator

### DIFF
--- a/helmfile/charts/kconmon/templates/agent/service.yaml
+++ b/helmfile/charts/kconmon/templates/agent/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+{{ include "kconmon.app.labels.standard" . | indent 4 }}
+    app: kconmon
+    component: agent
+  name: agent
+spec:
+  ports:
+  - name: http-web
+    port: 8080
+    protocol: TCP
+    targetPort: http-web
+  selector:
+    app: kconmon
+    component: agent
+  sessionAffinity: None
+  type: ClusterIP

--- a/helmfile/charts/kconmon/templates/agent/servicemonitor.yaml
+++ b/helmfile/charts/kconmon/templates/agent/servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: kconmon
+  name: kconmon-service-monitor
+  namespace: kconmon
+spec:
+  endpoints:
+  - interval: 5s
+    path: /metrics
+    port: http-web
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: kconmon
+      component: agent


### PR DESCRIPTION
Service "agent" will match any agent containers and expose it's ports.
ServiceMonitor "kconmon-service-monitor" will add target rules to prometheus operator.