### PR TITLE
Fix minor ServiceMonitor helm template

### DIFF
--- a/helmfile/charts/kconmon/templates/agent/servicemonitor.yaml
+++ b/helmfile/charts/kconmon/templates/agent/servicemonitor.yaml
@@ -4,8 +4,9 @@ kind: ServiceMonitor
 metadata:
   labels:
 {{ include "kconmon.app.labels.standard" . | indent 4 }}
+{{ toYaml .Values.prometheus.prometheusMatchLabels|trim | indent 4 }}
   name: kconmon-service-monitor
-  namespace: kconmon
+  namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
   - interval: 5s

--- a/helmfile/charts/kconmon/values.yaml
+++ b/helmfile/charts/kconmon/values.yaml
@@ -46,5 +46,7 @@ resources:
     memory: 45Mi
 
 prometheus:
-  # If you wish to create a service and a service monitor because you're using the prometheus operator, change this to true
+  # If you wish to create a service and a service monitor because you're using the prometheus operator, change this to true and set valid match label 
   enableServiceMonitor: false
+  prometheusMatchLabels:
+    prometheus: "prometheus-kconmon"


### PR DESCRIPTION
ServiceMonitor should have labels form proper Prometheus 'ServiceMonitorMatchLabel'. For matching one of the prometheus and the servicemonitor.
